### PR TITLE
add ignore for macro derive resolution for now

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![deny(warnings)]
+#![allow(proc_macro_derive_resolution_fallback)]
 
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
Compilation of the latest master fails with the diesel feature right now. This was fixed in upstream diesel half a year ago, however I could not get it to work.