### PR TITLE
Allow types to be used as compound keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ url = "1.7"
 
 [dependencies.diesel]
 optional = true
-version = "1.3"
+version = "1.4"
 
 [dev-dependencies]
 serde_json = "1.0"


### PR DESCRIPTION
This PR resolves a couple of issues I had when I tried to use `UserId` as a compound key.

* Updated the `FromSql` implementation, otherwise calling `first` fails with `expected struct `diesel::sqlite::connection::sqlite_value::SqliteValue`, found slice`
* Derive `QueryId`, `AsExpression`, `SqlType`, otherwise insert fails with `the trait diesel::Expression is not implemented for ruma_identifiers::UserId` (and a couple of other traits that are missing, like `diesel::expression::NonAggregate`, `diesel::AppearsOnTable` and `diesel::query_builder::QueryFragment`)

It also uses diesel 1.4, since 1.3 produces warnings like `names from parent modules are not accessible without an explicit import`, which are turned into errors by `#![deny(warnings)]`.

I've built a minimal application to illustrate the errors: https://github.com/exul/ruma-identifiers-sample

`master` contains the version that uses the current master and fails to compile, the branch `fix-diesel` uses the updated version as a dependency and compiles.

Other PRs mentioned that updates should wait for the next diesel release, but since 1.4 was released on January 21st, I thought I'd give it a shot. Feel free to comment/close if this is blocked by something else/not useful.